### PR TITLE
Fix for type check on return value of _getField

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,7 +57,7 @@ Meteor.user = function (input) {
 		var innocent = true;
 
 		input.forEach(function (item) {
-			if (typeof _getField(cache, item) === "undefined") {
+			if (!_getField(cache, item)) {
 				innocent = false;
 			}
 		})


### PR DESCRIPTION
The function _getField is returning a Boolean value due to type-coersion with `!!` so testing the return value against `undefined` would never succeed.  Instead we should be checking the state of the boolean which has been returned.